### PR TITLE
Drop patch numbers from deps versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/John15321/rust-pip"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.58", features = ["backtrace"] }
+anyhow = { version = "1.0", features = ["backtrace"] }
 clap = { version = "3.2", features = ["derive"] }
 reqwest = { version = "0.11", features = ["blocking", "json"] }
-strum = { version = "0.24.1", features = ["derive"] }
+strum = { version = "0.24", features = ["derive"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
There's usually no reason not to want a higher patch number, and Rust's semver bumps it anyway.