### PR TITLE
Added CI Job for linting Markdowns

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,13 @@ env:
     CARGO_TERM_COLOR: always
 
 jobs:
+    lint-markdowns:
+        name: Lint markdown files
+        runs-on: ubuntu-latest
+        steps:
+            - name: Lint markdown files 
+            - uses: actionshub/markdownlint@main
+
     build:
         name: 🔨Build release
         runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Lint markdown files 
-            - uses: actionshub/markdownlint@main
+              uses: actionshub/markdownlint@main
 
     build:
         name: 🔨Build release

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ enum Opt {
     Help {},
 }
 
-fn download_package(_package_name: String, _package_index: &String) {}
+fn download_package(_package_name: String, _package_index: &str) {}
 
 fn main() {
     let opt = Opt::from_args();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use structopt::StructOpt;
 
 /// A basic example
@@ -44,7 +43,7 @@ enum Opt {
     Help {},
 }
 
-fn download_package(package_name: String, package_index: &String) {}
+fn download_package(_package_name: String, _package_index: &String) {}
 
 fn main() {
     let opt = Opt::from_args();


### PR DESCRIPTION
This allows all Markdowns to have proper linting before they are pushed to the repository. 
This is to resolve Issue #40 